### PR TITLE
Fix for warning when using flutter_test. 

### DIFF
--- a/lib/src/dotenv.dart
+++ b/lib/src/dotenv.dart
@@ -66,7 +66,7 @@ class DotEnv {
   /// Logs to [stderr] if [filename] does not exist.
   Future load([String filename = '.env', Parser psr = const Parser()]) async {
     var lines = await _verify(filename);
-    env.addAll(psr.parse(lines));
+    _env.addAll(psr.parse(lines));
   }
 
   Future<List<String>> _verify(String filename) async {


### PR DESCRIPTION
Shell: [flutter_dotenv] No env values found. Make sure you have called DotEnv.load()

I believe there is some sort of race condition going on, as the env is actually being returned as expected right after the above message is given. After the change, the message no longer shows and the env is still returned as expected. 

![image](https://user-images.githubusercontent.com/17152619/64022109-1c2faf80-cafb-11e9-865c-d201ee96cf5d.png)

This is how I am using flutter_dotenv in the test to replicate. 


